### PR TITLE
Use LOG_LEVEL for ws_client logger

### DIFF
--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -7,6 +7,7 @@ from .config import settings
 from .redis_client import set_status
 
 logger = logging.getLogger(__name__)
+logger.setLevel(getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO))
 
 async def handle_message(message: str) -> None:
     try:


### PR DESCRIPTION
## Summary
- configure `ws_client` logger with log level from settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c27dd653c8328ad044323c4cf148a