### PR TITLE
Switch to FyersOrderSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 ```
 FYERS_APP_ID=your-app-id
 FYERS_ACCESS_TOKEN=access-token
-FYERS_WEBSOCKET_URL=wss://example.com/ws
+FYERS_SUBSCRIPTION_TYPE=OnOrders
 REDIS_URL=redis://localhost:6379/0
 LOG_LEVEL=INFO
 ```

--- a/listener/config.py
+++ b/listener/config.py
@@ -6,7 +6,7 @@ load_dotenv()
 class Settings:
     FYERS_APP_ID: str = os.getenv("FYERS_APP_ID", "")
     FYERS_ACCESS_TOKEN: str = os.getenv("FYERS_ACCESS_TOKEN", "")
-    FYERS_WEBSOCKET_URL: str = os.getenv("FYERS_WEBSOCKET_URL", "wss://example.com/ws")
+    FYERS_SUBSCRIPTION_TYPE: str = os.getenv("FYERS_SUBSCRIPTION_TYPE", "OnOrders")
 
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")

--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
 import logging
-import websockets
+from typing import Any, Dict
+
+from fyers_apiv3.FyersWebsocket.order_ws import FyersOrderSocket
 
 from .config import settings
 from .redis_client import set_status
@@ -9,25 +11,53 @@ from .redis_client import set_status
 logger = logging.getLogger(__name__)
 logger.setLevel(getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO))
 
-async def handle_message(message: str) -> None:
-    try:
-        data = json.loads(message)
-    except json.JSONDecodeError:
-        data = {"raw": message}
-    key = data.get("id", "last")
+async def handle_message(message: Any) -> None:
+    """Store a received WebSocket message in Redis."""
+    if isinstance(message, str):
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            data = {"raw": message}
+    else:
+        data = message
+
+    key = (
+        data.get("id")
+        or data.get("orders", {}).get("id")
+        or "last"
+    )
     set_status(f"fyers:{key}", json.dumps(data))
 
-async def connect_and_listen():
-    backoff = 1
+async def connect_and_listen() -> None:
+    """Connect to the Fyers WebSocket and process updates indefinitely."""
+    loop = asyncio.get_running_loop()
+
+    def dispatch(msg: Dict[str, Any]):
+        asyncio.run_coroutine_threadsafe(handle_message(msg), loop)
+
+    def on_connect() -> None:
+        logger.info("Connected to WebSocket")
+        socket.subscribe(settings.FYERS_SUBSCRIPTION_TYPE)
+        socket.keep_running()
+
+    def on_close(message: Dict[str, Any]) -> None:
+        logger.warning("WebSocket closed: %s", message)
+
+    def on_error(message: Dict[str, Any]) -> None:
+        logger.error("WebSocket error: %s", message)
+
+    socket = FyersOrderSocket(
+        access_token=settings.FYERS_ACCESS_TOKEN,
+        on_connect=on_connect,
+        on_close=on_close,
+        on_error=on_error,
+        on_general=dispatch,
+        on_orders=dispatch,
+        on_positions=dispatch,
+        on_trades=dispatch,
+    )
+
+    socket.connect()
+
     while True:
-        try:
-            async with websockets.connect(settings.FYERS_WEBSOCKET_URL) as ws:
-                logger.info("Connected to WebSocket")
-                await ws.send(json.dumps({"token": settings.FYERS_ACCESS_TOKEN}))
-                backoff = 1
-                async for message in ws:
-                    await handle_message(message)
-        except Exception as e:
-            logger.error("WebSocket error: %s", e)
-        await asyncio.sleep(backoff)
-        backoff = min(backoff * 2, 60)
+        await asyncio.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ uvicorn
 websockets~=11.0
 redis
 python-dotenv
+fyers-apiv3
 pytest
 pytest-asyncio
 httpx~=0.24


### PR DESCRIPTION
## Summary
- switch WebSocket implementation to `FyersOrderSocket`
- support FYERS_SUBSCRIPTION_TYPE env var
- update README for new variable
- add fyers-apiv3 dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3be56e1483289ff6aa225320b669