### PR TITLE
Add Makefile for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: install run test docker-build docker-run
+
+install:
+	pip install -r requirements.txt
+
+run:
+	python -m listener.main
+
+test:
+	pytest
+
+docker-build:
+	docker build -t websocket-listener .
+
+docker-run:
+	docker run -p 8000:8000 websocket-listener

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This service connects to the Fyers WebSocket API and mirrors order/position upda
 1. Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+make install
 ```
 
 2. Create a `.env` file with the following variables or export them in your environment:
@@ -23,10 +23,22 @@ LOG_LEVEL=INFO
 3. Run the service:
 
 ```bash
-python -m listener.main
+make run
 ```
 
 The health endpoint will be available on `http://localhost:8000/healthz`.
+
+## Makefile
+
+Common tasks are available via `make` commands:
+
+```bash
+make install       # install dependencies
+make run           # start the service
+make test          # run unit tests
+make docker-build  # build the Docker image
+make docker-run    # run the Docker container
+```
 
 ## Docker
 
@@ -50,7 +62,7 @@ kubectl apply -f k8s/deployment.yaml
 Run unit tests with:
 
 ```bash
-pytest
+make test
 ```
 
 ## Integration with Webhook Service


### PR DESCRIPTION
## Summary
- add a simple Makefile for installing dependencies, running the app, testing and Docker helpers
- document Makefile usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*


------
https://chatgpt.com/codex/tasks/task_e_685a315f791c8328a6f8eae9ced6e3f3