### PR TITLE
Switch to async Redis client

### DIFF
--- a/listener/redis_client.py
+++ b/listener/redis_client.py
@@ -1,4 +1,4 @@
-import redis
+import redis.asyncio as redis
 from .config import settings
 
 _redis = None
@@ -9,6 +9,6 @@ def get_client() -> redis.Redis:
         _redis = redis.from_url(settings.REDIS_URL)
     return _redis
 
-def set_status(key: str, value: str) -> None:
+async def set_status(key: str, value: str) -> None:
     client = get_client()
-    client.set(key, value)
+    await client.set(key, value)

--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -26,7 +26,7 @@ async def handle_message(message: Any) -> None:
         or data.get("orders", {}).get("id")
         or "last"
     )
-    set_status(f"fyers:{key}", json.dumps(data))
+    await set_status(f"fyers:{key}", json.dumps(data))
 
 async def connect_and_listen() -> None:
     """Connect to the Fyers WebSocket and process updates indefinitely."""

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -7,7 +7,7 @@ import pytest
 from listener import ws_client, redis_client
 
 class FakeRedis(dict):
-    def set(self, key, value):
+    async def set(self, key, value):
         self[key] = value
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- use `redis.asyncio` in `redis_client`
- await Redis operations in `ws_client`
- update tests for async Redis

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q setuptools`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c428e26d08328a8fc37216f747a8d