### PR TITLE
Switch to redis.asyncio

### DIFF
--- a/listener/redis_client.py
+++ b/listener/redis_client.py
@@ -1,4 +1,4 @@
-import redis
+import redis.asyncio as redis
 from .config import settings
 
 _redis = None
@@ -9,6 +9,6 @@ def get_client() -> redis.Redis:
         _redis = redis.from_url(settings.REDIS_URL)
     return _redis
 
-def set_status(key: str, value: str) -> None:
+async def set_status(key: str, value: str) -> None:
     client = get_client()
-    client.set(key, value)
+    await client.set(key, value)

--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -15,7 +15,7 @@ async def handle_message(message: str) -> None:
     except json.JSONDecodeError:
         data = {"raw": message}
     key = data.get("id", "last")
-    set_status(f"fyers:{key}", json.dumps(data))
+    await set_status(f"fyers:{key}", json.dumps(data))
 
 async def connect_and_listen():
     backoff = 1

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -7,7 +7,7 @@ import pytest
 from listener import ws_client, redis_client
 
 class FakeRedis(dict):
-    def set(self, key, value):
+    async def set(self, key, value):
         self[key] = value
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- use `redis.asyncio` in `redis_client`
- await Redis calls in `ws_client`
- adjust tests for async Redis usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2f1c8df88328bb86fae0a3ff79b1