### PR TITLE
Pin httpx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This service connects to the Fyers WebSocket API and mirrors order/position upda
 make install
 ```
 
+   This project requires `httpx` version `>=0.24,<0.25`.
+
 2. Create a `.env` file with the following variables or export them in your environment:
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ python-dotenv
 fyers-apiv3
 pytest
 pytest-asyncio
-httpx~=0.24
+httpx>=0.24,<0.25


### PR DESCRIPTION
## Summary
- pin `httpx` to `>=0.24,<0.25`
- document httpx version requirement in setup steps

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5240b12c8328af702178fa22ad93