### PR TITLE
Add retry logic with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ FYERS_ACCESS_TOKEN=access-token
 FYERS_SUBSCRIPTION_TYPE=OnOrders
 REDIS_URL=redis://localhost:6379/0
 LOG_LEVEL=INFO
+MAX_RETRIES=5
+RETRY_DELAY=1
 ```
 
 3. Run the service:

--- a/listener/config.py
+++ b/listener/config.py
@@ -10,5 +10,7 @@ class Settings:
 
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
+    MAX_RETRIES: int = int(os.getenv("MAX_RETRIES", "5"))
+    RETRY_DELAY: float = float(os.getenv("RETRY_DELAY", "1"))
 
 settings = Settings()

--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -57,7 +57,17 @@ async def connect_and_listen() -> None:
         on_trades=dispatch,
     )
 
-    socket.connect()
-
+    attempt = 0
     while True:
-        await asyncio.sleep(1)
+        try:
+            socket.connect()
+            attempt = 0
+            while True:
+                await asyncio.sleep(1)
+        except Exception:
+            attempt += 1
+            logger.exception("Connection attempt %s failed", attempt)
+            if attempt >= settings.MAX_RETRIES:
+                raise
+            delay = settings.RETRY_DELAY * 2 ** (attempt - 1)
+            await asyncio.sleep(delay)

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -22,3 +22,35 @@ async def test_handle_message_sets_redis(fake_redis):
     await ws_client.handle_message(message)
     assert fake_redis["fyers:123"] == message
 
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_retries(monkeypatch):
+    attempts = 0
+
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def subscribe(self, *args, **kwargs):
+            pass
+
+        def keep_running(self):
+            pass
+
+        def connect(self):
+            nonlocal attempts
+            attempts += 1
+            raise RuntimeError("fail")
+
+    async def fake_sleep(_):
+        pass
+
+    monkeypatch.setattr(ws_client, "FyersOrderSocket", FakeSocket)
+    monkeypatch.setattr(ws_client.settings, "MAX_RETRIES", 3, raising=False)
+    monkeypatch.setattr(ws_client.settings, "RETRY_DELAY", 0, raising=False)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError):
+        await ws_client.connect_and_listen()
+    assert attempts == 3
+


### PR DESCRIPTION
## Summary
- add MAX_RETRIES and RETRY_DELAY configuration
- retry websocket connection with exponential backoff and log failures
- document new environment variables
- test connection retries with a failing socket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c524960048328bcad8b13e7f3b16e