### PR TITLE
Improve Redis client error handling

### DIFF
--- a/listener/redis_client.py
+++ b/listener/redis_client.py
@@ -1,14 +1,25 @@
+import logging
 import redis.asyncio as redis
 from .config import settings
 
+logger = logging.getLogger(__name__)
+
 _redis = None
 
-def get_client() -> redis.Redis:
+async def get_client(timeout: float | None = None) -> redis.Redis:
     global _redis
     if _redis is None:
-        _redis = redis.from_url(settings.REDIS_URL)
+        _redis = redis.from_url(settings.REDIS_URL, socket_timeout=timeout)
+        try:
+            await _redis.ping()
+        except Exception:
+            logger.exception("Redis connection failed")
+            raise
     return _redis
 
-async def set_status(key: str, value: str) -> None:
-    client = get_client()
-    await client.set(key, value)
+async def set_status(key: str, value: str, timeout: float | None = None) -> None:
+    client = await get_client(timeout)
+    try:
+        await client.set(key, value)
+    except Exception:
+        logger.exception("Failed to set key %s", key)

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -1,0 +1,17 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import logging
+import pytest
+
+from listener import redis_client
+
+class ErrorRedis:
+    async def set(self, key, value):
+        raise RuntimeError("boom")
+
+@pytest.mark.asyncio
+async def test_set_status_logs_error(monkeypatch, caplog):
+    err = ErrorRedis()
+    monkeypatch.setattr(redis_client, "_redis", err, raising=False)
+    with caplog.at_level(logging.ERROR):
+        await redis_client.set_status("k", "v")
+    assert "Failed to set key" in caplog.text


### PR DESCRIPTION
## Summary
- add logging to `redis_client` and verify connection on initialization
- support optional timeout when creating Redis clients
- log errors when set operations fail
- add tests for new Redis client logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5386656c8328af8bcca501f2f69e