### PR TITLE
Improve logging configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+ENV LOG_LEVEL=INFO
 CMD ["python", "-m", "listener.main"]

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,10 +26,12 @@ spec:
                 secretKeyRef:
                   name: fyers-secret
                   key: access_token
-            - name: FYERS_WEBSOCKET_URL
-              value: wss://example.com/ws
-            - name: REDIS_URL
-              value: redis://redis:6379/0
+        - name: FYERS_WEBSOCKET_URL
+          value: wss://example.com/ws
+        - name: REDIS_URL
+          value: redis://redis:6379/0
+        - name: LOG_LEVEL
+          value: INFO
           ports:
             - containerPort: 8000
           readinessProbe:

--- a/listener/config.py
+++ b/listener/config.py
@@ -1,7 +1,10 @@
 import os
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 class Settings:
     FYERS_APP_ID: str = os.getenv("FYERS_APP_ID", "")

--- a/listener/health.py
+++ b/listener/health.py
@@ -1,4 +1,7 @@
 from fastapi import FastAPI
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 

--- a/listener/redis_client.py
+++ b/listener/redis_client.py
@@ -9,6 +9,7 @@ _redis = None
 async def get_client(timeout: float | None = None) -> redis.Redis:
     global _redis
     if _redis is None:
+        logger.info("Connecting to Redis at %s", settings.REDIS_URL)
         _redis = redis.from_url(settings.REDIS_URL, socket_timeout=timeout)
         try:
             await _redis.ping()

--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -20,6 +20,7 @@ async def handle_message(message: Any) -> None:
             data = {"raw": message}
     else:
         data = message
+    logger.debug("Received message: %s", data)
 
     key = (
         data.get("id")
@@ -60,6 +61,7 @@ async def connect_and_listen() -> None:
     attempt = 0
     while True:
         try:
+            logger.info("Connecting to Fyers WebSocket")
             socket.connect()
             attempt = 0
             while True:


### PR DESCRIPTION
## Summary
- configure `LOG_LEVEL` in Docker image and k8s manifest
- ensure every module has its own logger
- log when connecting to Redis and the Fyers websocket
- debug log every received websocket message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c56a4da2c83289d563a1f3b2014d4