### PR TITLE
Improve configuration with typed Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ make install
 
    This project requires `httpx` version `>=0.24,<0.25`.
 
-2. Create a `.env` file with the following variables (or export them in your environment). The `Settings` class
-   in `listener/config.py` uses Pydantic `BaseSettings` to automatically load this file:
+2. Create a `.env` file with the following variables (or export them in your environment).
+   The `Settings` class in `listener/config.py` uses `pydantic.BaseSettings` to
+   load and validate these values. Import `settings` from `listener.config` in
+   your code to access them:
 
 ```
 FYERS_APP_ID=your-app-id

--- a/listener/config.py
+++ b/listener/config.py
@@ -1,22 +1,23 @@
 """Application configuration handled via Pydantic settings."""
 
 try:  # Pydantic <2.5
-    from pydantic import BaseSettings
-except Exception:  # pragma: no cover - fall back for Pydantic >=2.0
+    from pydantic import BaseSettings, Field
+except ImportError:  # pragma: no cover - fall back for Pydantic >=2.0
     from pydantic_settings import BaseSettings  # type: ignore
+    from pydantic import Field
 
 
 class Settings(BaseSettings):
     """Validate and expose environment configuration."""
 
-    FYERS_APP_ID: str = ""
-    FYERS_ACCESS_TOKEN: str = ""
-    FYERS_SUBSCRIPTION_TYPE: str = "OnOrders"
+    FYERS_APP_ID: str = Field("", env="FYERS_APP_ID")
+    FYERS_ACCESS_TOKEN: str = Field("", env="FYERS_ACCESS_TOKEN")
+    FYERS_SUBSCRIPTION_TYPE: str = Field("OnOrders", env="FYERS_SUBSCRIPTION_TYPE")
 
-    REDIS_URL: str = "redis://localhost:6379/0"
-    LOG_LEVEL: str = "INFO"
-    MAX_RETRIES: int = 5
-    RETRY_DELAY: float = 1.0
+    REDIS_URL: str = Field("redis://localhost:6379/0", env="REDIS_URL")
+    LOG_LEVEL: str = Field("INFO", env="LOG_LEVEL")
+    MAX_RETRIES: int = Field(5, env="MAX_RETRIES")
+    RETRY_DELAY: float = Field(1.0, env="RETRY_DELAY")
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- enforce typed configuration through `Settings` class
- document how to access validated settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5ad7363c8328a8ba9b9ae31ad30a