### PR TITLE
Fix container env nesting

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,12 +26,12 @@ spec:
                 secretKeyRef:
                   name: fyers-secret
                   key: access_token
-        - name: FYERS_WEBSOCKET_URL
-          value: wss://example.com/ws
-        - name: REDIS_URL
-          value: redis://redis:6379/0
-        - name: LOG_LEVEL
-          value: INFO
+            - name: FYERS_WEBSOCKET_URL
+              value: wss://example.com/ws
+            - name: REDIS_URL
+              value: redis://redis:6379/0
+            - name: LOG_LEVEL
+              value: INFO
           ports:
             - containerPort: 8000
           readinessProbe:


### PR DESCRIPTION
## Summary
- fix indentation in k8s deployment so env vars, ports, probes and resources are under the websocket-listener container
- attempt `kubectl apply --dry-run=client`

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*
- `kubectl apply --dry-run=client -f k8s/deployment.yaml` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685c62db30288328909a3b119f8983c7