### PR TITLE
Fix Makefile venv target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,6 @@ docker-run:
 	docker run -p 8000:8000 websocket-listener
 
 venv:
-    python -m venv .venv
-    . .venv/bin/activate && pip install -r requirements.txt
+	python -m venv .venv
+	. .venv/bin/activate && pip install -r requirements.txt
+


### PR DESCRIPTION
## Summary
- fix indentation in the `venv` target to use tabs
- add trailing newline

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c62d7d4f883288a5c402577a89df7