### PR TITLE
Fix redis status error handling

### DIFF
--- a/listener/redis_client.py
+++ b/listener/redis_client.py
@@ -24,3 +24,4 @@ async def set_status(key: str, value: str, timeout: float | None = None) -> None
         await client.set(key, value)
     except Exception:
         logger.exception("Failed to set key %s", key)
+        raise

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -27,7 +27,8 @@ async def test_set_status_logs_error(monkeypatch, caplog):
     err = ErrorRedis()
     monkeypatch.setattr(redis_client, "_redis", err, raising=False)
     with caplog.at_level(logging.ERROR):
-        await redis_client.set_status("k", "v")
+        with pytest.raises(RuntimeError):
+            await redis_client.set_status("k", "v")
     assert "Failed to set key" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- re-raise errors in `listener.redis_client.set_status`
- update tests to expect raised exception

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c6405268083288e15c7cc542a6c0a