### PR TITLE
Fix logging configuration

### DIFF
--- a/listener/ws_client.py
+++ b/listener/ws_client.py
@@ -9,7 +9,6 @@ from .config import settings
 from .redis_client import set_status
 
 logger = logging.getLogger(__name__)
-logger.setLevel(getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO))
 
 async def handle_message(message: Any) -> None:
     """Store a received WebSocket message in Redis."""


### PR DESCRIPTION
## Summary
- remove per-module log level from `ws_client`
- rely on the single `logging.basicConfig` call in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c64d2271c83289c0f0c6226b62382