### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: install install-dev run test docker-build docker-run
 
 install:
-        pip install -r requirements.txt
+	pip install -r requirements.txt
 
 install-dev: install
-        pip install -r requirements-dev.txt
+	pip install -r requirements-dev.txt
 
 run:
 	python -m listener.main


### PR DESCRIPTION
## Summary
- replace spaces with tabs in `install` targets

## Testing
- `grep -n $'\t' Makefile`

------
https://chatgpt.com/codex/tasks/task_e_685c61cf5d048328a68c2b0df0ecbc45