### PR TITLE
Add Fyers auth helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ make install-dev        # production + testing
 
 ```
 FYERS_APP_ID=your-app-id
+FYERS_SECRET_KEY=your-secret
+FYERS_REDIRECT_URI=https://your-app/callback
 FYERS_ACCESS_TOKEN=access-token
 FYERS_SUBSCRIPTION_TYPE=OnOrders
 REDIS_URL=redis://localhost:6379/0
@@ -27,6 +29,15 @@ LOG_LEVEL=INFO
 MAX_RETRIES=5
 RETRY_DELAY=1
 ```
+
+Run `python -m listener.auth` to generate a login URL. After logging in and
+authorising the app, copy the `auth_code` from the redirect and run
+
+```bash
+python -m listener.auth --auth-code <code> --write-env
+```
+
+This prints the access token and writes it to `.env` when `--write-env` is used.
 
 3. Run the service:
 

--- a/listener/auth.py
+++ b/listener/auth.py
@@ -1,0 +1,68 @@
+"""Utility helpers to authenticate with the Fyers API."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+from typing import Any, Dict
+
+from fyers_apiv3 import fyersModel
+
+from .config import settings
+
+
+def _build_session() -> fyersModel.SessionModel:
+    """Create a configured SessionModel."""
+    return fyersModel.SessionModel(
+        client_id=settings.FYERS_APP_ID,
+        secret_key=settings.FYERS_SECRET_KEY,
+        redirect_uri=settings.FYERS_REDIRECT_URI,
+        response_type="code",
+        grant_type="authorization_code",
+    )
+
+
+def generate_login_url() -> str:
+    """Return the URL that begins the Fyers login flow."""
+    session = _build_session()
+    return session.generate_authcode()
+
+
+async def exchange_auth_code(code: str) -> str:
+    """Exchange an authorization code for an access token."""
+    session = _build_session()
+    session.set_token(code)
+    loop = asyncio.get_running_loop()
+    response: Dict[str, Any] = await loop.run_in_executor(None, session.generate_token)
+    return response.get("access_token", "")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Simple CLI helper for generating tokens."""
+    parser = argparse.ArgumentParser(description="Fyers authentication helper")
+    parser.add_argument("--auth-code", help="Authorization code from login redirect")
+    parser.add_argument(
+        "--write-env",
+        action="store_true",
+        help="Write the resulting token to the .env file",
+    )
+    args = parser.parse_args(argv)
+
+    if args.auth_code:
+        token = asyncio.run(exchange_auth_code(args.auth_code))
+        if args.write_env:
+            env = Path(".env")
+            lines = []
+            if env.exists():
+                lines = [l.rstrip("\n") for l in env.read_text().splitlines() if l.strip()]
+                lines = [l for l in lines if not l.startswith("FYERS_ACCESS_TOKEN=")]
+            lines.append(f"FYERS_ACCESS_TOKEN={token}")
+            env.write_text("\n".join(lines) + "\n")
+        print(token)
+    else:
+        print(generate_login_url())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/listener/config.py
+++ b/listener/config.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     """Validate and expose environment configuration."""
 
     FYERS_APP_ID: str = Field("", env="FYERS_APP_ID")
+    FYERS_SECRET_KEY: str = Field("", env="FYERS_SECRET_KEY")
+    FYERS_REDIRECT_URI: str = Field("", env="FYERS_REDIRECT_URI")
     FYERS_ACCESS_TOKEN: str = Field("", env="FYERS_ACCESS_TOKEN")
     FYERS_SUBSCRIPTION_TYPE: str = Field("OnOrders", env="FYERS_SUBSCRIPTION_TYPE")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,37 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import asyncio
+import pytest
+
+from listener import auth
+
+
+class FakeSession:
+    def __init__(self, *args, **kwargs):
+        self.token = None
+
+    def set_token(self, token):
+        self.token = token
+
+    def generate_authcode(self):
+        return "url"
+
+    def generate_token(self):
+        return {"access_token": "TOKEN"}
+
+
+@pytest.mark.asyncio
+async def test_exchange_auth_code(monkeypatch):
+    monkeypatch.setattr(auth.fyersModel, "SessionModel", lambda *a, **k: FakeSession())
+
+    token = await auth.exchange_auth_code("code")
+
+    assert token == "TOKEN"
+
+
+def test_generate_login_url(monkeypatch):
+    session = FakeSession()
+    monkeypatch.setattr(auth.fyersModel, "SessionModel", lambda *a, **k: session)
+
+    url = auth.generate_login_url()
+
+    assert url == "url"


### PR DESCRIPTION
## Summary
- include FYERS_SECRET_KEY and FYERS_REDIRECT_URI in settings
- implement `listener.auth` module for generating login URLs and exchanging auth codes
- provide a simple CLI for acquiring the access token
- document the new auth workflow in the README
- add unit tests for the auth helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c6e6b547483289038772eaf3611d4