### PR TITLE
Support auth code exchange at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ FYERS_APP_ID=your-app-id
 FYERS_SECRET_KEY=your-secret
 FYERS_REDIRECT_URI=https://your-app/callback
 FYERS_ACCESS_TOKEN=access-token
+FYERS_AUTH_CODE=optional-auth-code
 FYERS_SUBSCRIPTION_TYPE=OnOrders
 REDIS_URL=redis://localhost:6379/0
 LOG_LEVEL=INFO
@@ -38,6 +39,9 @@ python -m listener.auth --auth-code <code> --write-env
 ```
 
 This prints the access token and writes it to `.env` when `--write-env` is used.
+Alternatively, you can provide `FYERS_AUTH_CODE` to the service. If
+`FYERS_ACCESS_TOKEN` is empty, the listener will automatically exchange the
+authorization code for an access token on startup.
 
 3. Run the service:
 

--- a/listener/config.py
+++ b/listener/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     FYERS_SECRET_KEY: str = Field("", env="FYERS_SECRET_KEY")
     FYERS_REDIRECT_URI: str = Field("", env="FYERS_REDIRECT_URI")
     FYERS_ACCESS_TOKEN: str = Field("", env="FYERS_ACCESS_TOKEN")
+    FYERS_AUTH_CODE: str = Field("", env="FYERS_AUTH_CODE")
     FYERS_SUBSCRIPTION_TYPE: str = Field("OnOrders", env="FYERS_SUBSCRIPTION_TYPE")
 
     REDIS_URL: str = Field("redis://localhost:6379/0", env="REDIS_URL")


### PR DESCRIPTION
## Summary
- support a new `FYERS_AUTH_CODE` config field
- automatically exchange the auth code for an access token on startup
- document auth code usage in README
- test automatic token exchange logic

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685ccb9592a88328a5ef5ac9a717eca9