### PR TITLE
Add Fyers token refresh logic

### DIFF
--- a/listener/config.py
+++ b/listener/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     FYERS_REDIRECT_URI: str = Field("", env="FYERS_REDIRECT_URI")
     FYERS_ACCESS_TOKEN: str = Field("", env="FYERS_ACCESS_TOKEN")
     FYERS_AUTH_CODE: str = Field("", env="FYERS_AUTH_CODE")
+    FYERS_REFRESH_TOKEN: str = Field("", env="FYERS_REFRESH_TOKEN")
+    FYERS_PIN: str = Field("", env="FYERS_PIN")
     FYERS_SUBSCRIPTION_TYPE: str = Field("OnOrders", env="FYERS_SUBSCRIPTION_TYPE")
 
     REDIS_URL: str = Field("redis://localhost:6379/0", env="REDIS_URL")


### PR DESCRIPTION
## Summary
- support optional `FYERS_REFRESH_TOKEN` and `FYERS_PIN`
- refresh websocket token on auth failures
- provide helper to refresh tokens
- test refresh logic

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686295551ed88328a052ff1b55296434