### PR TITLE
Improve auth code setup docs

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,11 +21,16 @@ spec:
                 secretKeyRef:
                   name: fyers-secret
                   key: app_id
-            - name: FYERS_ACCESS_TOKEN
+            - name: FYERS_AUTH_CODE
               valueFrom:
                 secretKeyRef:
                   name: fyers-secret
-                  key: access_token
+                  key: auth_code
+            - name: FYERS_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fyers-secret
+                  key: refresh_token
             - name: FYERS_WEBSOCKET_URL
               value: wss://example.com/ws
             - name: REDIS_URL


### PR DESCRIPTION
## Summary
- clarify environment variables for auth code usage
- mention automatic exchange of the auth code on startup
- update Kubernetes deployment example to use auth code instead of access token

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `make test` *(fails: KeyboardInterrupt after 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686299fe5c28832880cf63c122b42632