### PR TITLE
Handle refresh token in auth exchange

### DIFF
--- a/listener/main.py
+++ b/listener/main.py
@@ -27,11 +27,15 @@ def main():
     if not settings.FYERS_ACCESS_TOKEN and settings.FYERS_AUTH_CODE:
         logger.info("Exchanging auth code for access token")
         try:
-            token = asyncio.run(auth.exchange_auth_code(settings.FYERS_AUTH_CODE))
-            if token:
-                settings.FYERS_ACCESS_TOKEN = token
+            access, refresh = asyncio.run(
+                auth.exchange_auth_code(settings.FYERS_AUTH_CODE)
+            )
+            if access:
+                settings.FYERS_ACCESS_TOKEN = access
             else:
                 logger.warning("Auth code exchange returned empty token")
+            if refresh:
+                settings.FYERS_REFRESH_TOKEN = refresh
         except Exception:
             logger.exception("Failed to exchange auth code")
     logger.info("Starting WebSocket listener")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,16 +16,17 @@ class FakeSession:
         return "url"
 
     def generate_token(self):
-        return {"access_token": "TOKEN"}
+        return {"access_token": "TOKEN", "refresh_token": "REF"}
 
 
 @pytest.mark.asyncio
 async def test_exchange_auth_code(monkeypatch):
     monkeypatch.setattr(auth.fyersModel, "SessionModel", lambda *a, **k: FakeSession())
 
-    token = await auth.exchange_auth_code("code")
+    access, refresh = await auth.exchange_auth_code("code")
 
-    assert token == "TOKEN"
+    assert access == "TOKEN"
+    assert refresh == "REF"
 
 
 def test_generate_login_url(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,12 +70,13 @@ def test_main_exchanges_auth_code(monkeypatch):
 
     async def fake_exchange(code):
         events["code"] = code
-        return "TOKEN123"
+        return "TOKEN123", "REFRESH123"
 
     monkeypatch.setattr(main_mod.auth, "exchange_auth_code", fake_exchange)
 
     async def fake_connect_and_listen():
         events["token"] = main_mod.settings.FYERS_ACCESS_TOKEN
+        events["refresh"] = main_mod.settings.FYERS_REFRESH_TOKEN
 
     monkeypatch.setattr(main_mod, "connect_and_listen", fake_connect_and_listen)
 
@@ -90,6 +91,7 @@ def test_main_exchanges_auth_code(monkeypatch):
     monkeypatch.setattr(main_mod.threading, "Thread", FakeThread)
 
     monkeypatch.setattr(main_mod.settings, "FYERS_ACCESS_TOKEN", "", raising=False)
+    monkeypatch.setattr(main_mod.settings, "FYERS_REFRESH_TOKEN", "", raising=False)
     monkeypatch.setattr(main_mod.settings, "FYERS_AUTH_CODE", "CODE", raising=False)
 
     def fake_asyncio_run(coro):
@@ -105,3 +107,4 @@ def test_main_exchanges_auth_code(monkeypatch):
 
     assert events["code"] == "CODE"
     assert events["token"] == "TOKEN123"
+    assert events["refresh"] == "REFRESH123"


### PR DESCRIPTION
## Summary
- support returning refresh token from `exchange_auth_code`
- persist both access and refresh tokens in `main`
- adjust CLI utility for the new tuple return
- update unit tests for refresh token handling

## Testing
- `pip install -q -r requirements.txt` *(fails: could not access pypi.org)*
- `pytest -q` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd4532448328be5a660120f1a4ae